### PR TITLE
Fix "elif" condition to use "cfq" and remove a useless verification …

### DIFF
--- a/s820/performance.sh
+++ b/s820/performance.sh
@@ -396,7 +396,7 @@ if [ "$deadline" == "true" ]; then
 		echo 0 > /sys/block/mmcblk0rpmb/queue/rotational
 		echo 1 > /sys/block/mmcblk0rpmb/queue/rq_affinity
 	fi
-elif [ "$deadline" == "false" ] && [ "cfq" == "true" ]; then
+elif [ "$cfq" == "true" ]; then
 	if [ -e $string3 ]; then
 		echo "setting cfq"
 		echo 512 > /sys/block/mmcblk0/bdi/read_ahead_kb


### PR DESCRIPTION
…since you're using a "elif" you don't need to confirm deadline value because if it reaches "elfi" deadline must be false