### PR TITLE
Fix "elif" condition to use "noop" and remove a useless verification …

### DIFF
--- a/s810/suspend.sh
+++ b/s810/suspend.sh
@@ -441,7 +441,7 @@ if [ "$maple" == "true" ]; then
 		echo 0 > /sys/block/mmcblk0rpmb/queue/rotational
 		echo 1 > /sys/block/mmcblk0rpmb/queue/rq_affinity
 	fi
-elif [ "$maple" == "false" ] && [ "noop" == "true" ]; then
+elif [ "$noop" == "true" ]; then
 	if [ -e $string3 ]; then
 		echo "setting noop"
 		echo 1024 > /sys/block/mmcblk0/bdi/read_ahead_kb


### PR DESCRIPTION
…since you're using a "elif" you don't need to confirm maple value because if it reaches "elfi" mapple must be false