### PR TITLE
Fix "elif" condition to use "cfq" and remove a useless verification s…

### DIFF
--- a/s808/performance.sh
+++ b/s808/performance.sh
@@ -394,7 +394,7 @@ if [ -e $string3 ]; then
 		echo 0 > /sys/block/mmcblk0rpmb/queue/rotational
 		echo 1 > /sys/block/mmcblk0rpmb/queue/rq_affinity
 		
-	elif [ "$deadline" == "false" ] && [ "cfq" == "true" ]; then
+	elif [ "$cfq" == "true" ]; then
 		echo "setting cfq"
 		echo 512 > /sys/block/mmcblk0/bdi/read_ahead_kb
 		echo "cfq" > /sys/block/mmcblk0/queue/scheduler


### PR DESCRIPTION
…ince you're using a "elif" you don't need to confirm deadline value because if it reaches "elfi" deadline must be false